### PR TITLE
Falling room panels

### DIFF
--- a/resources/graphics/PanelsBlank.png
+++ b/resources/graphics/PanelsBlank.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18511824b3c17f52fc0eb435bf60c97e780dba8123741e160d3494453dc36629
+size 2181

--- a/resources/graphics/PanelsDiamondFour.png
+++ b/resources/graphics/PanelsDiamondFour.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd8a8cbcd167754c6d68c70573a8848828a76420baca0a1aba02d54c3c21fc77
+size 5673

--- a/resources/graphics/PanelsDiamondOne.png
+++ b/resources/graphics/PanelsDiamondOne.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae8ef4d87a230dcad68b5ba0f3c8c51263c7fd5e05137acafe557ed6c3930e13
+size 3243

--- a/resources/graphics/PanelsDiamondThree.png
+++ b/resources/graphics/PanelsDiamondThree.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1c26f631fc927ec04be0f99c40ad376a0475716b73aa4f5a8b613f6153a6fb8
+size 5589

--- a/resources/graphics/PanelsDiamondTwo.png
+++ b/resources/graphics/PanelsDiamondTwo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99d1bde8ff785a391913da98bde1ff31142fa6f1cc48607b18a6b624c27c8198
+size 4702

--- a/resources/graphics/PanelsGoal.png
+++ b/resources/graphics/PanelsGoal.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da5aa98a5dac4f5a068a3255411fc13747e805187593779d924bcf81ef037da5
+size 2566

--- a/resources/graphics/PanelsSkull.png
+++ b/resources/graphics/PanelsSkull.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f3091730721d3af548ec9b10fa5e93fad10a5eb021e0501786b007ba43815cb
+size 2733

--- a/src/Actors/ActorComponents.h
+++ b/src/Actors/ActorComponents.h
@@ -26,6 +26,7 @@ namespace Actors
 	{
 		sf::Sprite sprite;
 		bool isVisible = true;
+		bool isBackground = false;
 		float initialTextureAngle = 0.f;
 	};
 

--- a/src/Actors/ActorComponents.h
+++ b/src/Actors/ActorComponents.h
@@ -75,5 +75,6 @@ namespace Actors
 		State ActorState = STEADY;
 		float currentScale = 1.f;
 		float verticalTime = 3.f;
+		Physics::Vec2f voidCentre = Physics::Vec2f(0.f, 0.f);
 	};
 }

--- a/src/Actors/ActorEntityManager.cpp
+++ b/src/Actors/ActorEntityManager.cpp
@@ -2,12 +2,24 @@
 
 namespace Actors
 {
-	void ActorEntityManager::renderActors(sf::RenderWindow& window)
+	void ActorEntityManager::renderForegroundActors(sf::RenderWindow& window)
 	{
-		window.draw(graphicsComponents[0].sprite);
+		//window.draw(graphicsComponents[0].sprite);
 		for (const ActorGraphicsComponent& graphics : graphicsComponents)
 		{
-			if (graphics.isVisible)
+			if (graphics.isVisible && !graphics.isBackground)
+			{
+				window.draw(graphics.sprite);
+			}
+		}
+	}
+
+	void ActorEntityManager::renderBackgroundActors(sf::RenderWindow& window)
+	{
+		//window.draw(graphicsComponents[0].sprite);
+		for (const ActorGraphicsComponent& graphics : graphicsComponents)
+		{
+			if (graphics.isVisible && graphics.isBackground)
 			{
 				window.draw(graphics.sprite);
 			}
@@ -49,6 +61,8 @@ namespace Actors
 
 			if (actor.components.test(Actors::ActorComponentTypes::GRAVITY))
 			{
+				graphics.isBackground = gravityComponents[actor.id].ActorState
+					!= ActorGravityComponent::STEADY;
 				float currentScale = gravityComponents[actor.id].currentScale;
 				float width = transformComponents[actor.id].width * currentScale;
 				float height = transformComponents[actor.id].height * currentScale;

--- a/src/Actors/ActorEntityManager.h
+++ b/src/Actors/ActorEntityManager.h
@@ -23,7 +23,8 @@ namespace Actors
 		void unassignActor(int id);
 		void moveActors(float deltaTime);
 		void updateGraphics();
-		void renderActors(sf::RenderWindow& window);
+		void renderForegroundActors(sf::RenderWindow& window);
+		void renderBackgroundActors(sf::RenderWindow& window);
 		
 		void setReferenceLength(float length);
 		void updateReferenceLength(float length);

--- a/src/Actors/ActorEntitySystem.cpp
+++ b/src/Actors/ActorEntitySystem.cpp
@@ -49,7 +49,9 @@ namespace Actors
 		actorCollision.rectangle.setPosition(actorTransform.position);
 	}
 
-	void ActorEntitySystem::adjustGravityMotion(ActorGravityComponent& gravity)
+	void ActorEntitySystem::adjustGravityMotion(
+		ActorGravityComponent& gravity, 
+		ActorTransformComponent& transform)
 	{
 		if (gravity.ActorState == ActorGravityComponent::STEADY)
 		{
@@ -67,6 +69,8 @@ namespace Actors
 			{
 				gravity.ActorState = ActorGravityComponent::VANISHED;
 			}
+			transform.position += (gravity.voidCentre - transform.position) * 0.004f;
+
 			break;
 		case ActorGravityComponent::VANISHED:
 			gravity.currentScale = 0.f;

--- a/src/Actors/ActorEntitySystem.h
+++ b/src/Actors/ActorEntitySystem.h
@@ -22,7 +22,10 @@ namespace Actors
 			Physics::Vec2f floorForce
 		);
 
-		static void adjustGravityMotion(ActorGravityComponent& gravity);
+		static void adjustGravityMotion(
+			ActorGravityComponent& gravity,
+			ActorTransformComponent& transform
+		);
 
 	private:
 		static float m_deltaTime;

--- a/src/Assets/TextureDict.cpp
+++ b/src/Assets/TextureDict.cpp
@@ -18,9 +18,10 @@ namespace Assets
 	{
 		if (m_textures.find(name) == m_textures.end())
 		{
-			throw std::invalid_argument(
-				"Key '" + name + "' not found in _textures map of TextureDict."
-			);
+			this->loadTexture(name);
+			//throw std::invalid_argument(
+			//	"Key '" + name + "' not found in _textures map of TextureDict."
+			//);
 		}
 
 		return m_textures[name];
@@ -28,9 +29,7 @@ namespace Assets
 
 	void TextureDict::loadTexture(std::string name)
 	{
-
-		// Specify the relative path to your image file
-   
+		// Specify the relative path to the image file
 		// Create the full path by concatenating the executable path and the relative image path
 		m_textures[name].loadFromFile(
 			m_exePath + "/" + m_relativePath + "resources/graphics/" + name + ".png");

--- a/src/Levels/CellComponents.h
+++ b/src/Levels/CellComponents.h
@@ -80,8 +80,11 @@ namespace Levels
 	{
 		std::array<CellStaticRectangle, 8> staticWalls;
 		std::vector<CellStaticRectangle> staticFloors;
+		CellStaticRectangle blocker;
+
 		Physics::Circle broadCircle;
 		float relativeBroadRadius;
+		bool isBlocked = false;
 		bool isFloorActive = true;
 		bool areCollisionsActive = true;
 	};

--- a/src/Levels/CellComponents.h
+++ b/src/Levels/CellComponents.h
@@ -26,13 +26,15 @@ namespace Levels
 	public:
 		static enum
 		{
-		TYPE = 0,
-		GRAPHICS = 1,
-		TRANSFORM = 2,
-		NUMBERS = 3,
-		COLLISION = 4,
-		FORCE = 5,
-		MOVE = 6
+		TYPE,
+		GRAPHICS,
+		TRANSFORM,
+		COLLISION,
+		NUMBERS,
+		PANELS,
+		FORCE,
+		MOVE,
+
 		};
 	};
 
@@ -140,6 +142,11 @@ namespace Levels
 		sf::Text text;
 		CellPanel currentPanel = CellPanel::TOP_LEFT;
 		Physics::Vec2f relativePosition = Physics::Vec2f(0.f, 0.f);
+	};
+
+	struct CellPanelsComponent
+	{
+		
 	};
 }
 

--- a/src/Levels/CellComponents.h
+++ b/src/Levels/CellComponents.h
@@ -34,7 +34,6 @@ namespace Levels
 		PANELS,
 		FORCE,
 		MOVE,
-
 		};
 	};
 
@@ -42,6 +41,7 @@ namespace Levels
 	{
 		sf::Sprite sprite;
 		bool isVisible = true;
+		bool isBackground = true;
 		float textureRotation = 0.f;
 	};
 

--- a/src/Levels/DetectedLevelCollisions.h
+++ b/src/Levels/DetectedLevelCollisions.h
@@ -11,6 +11,7 @@ namespace Levels
 	{
 	public:
 		std::vector<Physics::RectParams> staticWalls;
+		std::vector<Physics::RectParams> blockers;
 		bool isFloorDetected = false;
 		Physics::Vec2f floorForce = Physics::Vec2f(0.f, 0.f);
 		Physics::Vec2f voidCentre = Physics::Vec2f(0.f, 0.f);

--- a/src/Levels/LevelEntityManager.cpp
+++ b/src/Levels/LevelEntityManager.cpp
@@ -112,6 +112,7 @@ namespace Levels
  
 		for (LevelMoveAction& action : m_currentMoveActions)
 		{
+
 			switch (action.getCurrentActionState())
 			{
 			case LevelMoveAction::STARTING:
@@ -151,6 +152,18 @@ namespace Levels
 			default:
 				break;
 			};
+
+
+			switch (action.getCurrentActionState())
+			{
+			case LevelMoveAction::DROPPING:
+			case LevelMoveAction::CLIMBING:
+				m_cellGraphicsComponents[action.getDropCellId()].isBackground = true;
+				break;
+			default:
+				m_cellGraphicsComponents[action.getDropCellId()].isBackground = false;
+				break;
+			};
 		}
 
 		// Remove actions which have completed (ended)
@@ -172,6 +185,13 @@ namespace Levels
 	void LevelEntityManager::renderBackground(sf::RenderWindow& window)
 	{
 		window.draw(m_backgroundSprite);
+		for (CellGraphicsComponent graphics : this->m_cellGraphicsComponents)
+		{
+			if (graphics.isBackground)
+			{
+				window.draw(graphics.sprite);
+			}
+		}
 	}
 
 
@@ -179,6 +199,10 @@ namespace Levels
 	{
 		for (int i = 0; i < m_totalCells; i++)
 		{
+			if (m_cellGraphicsComponents[i].isBackground)
+			{
+				continue;
+			}
 			window.draw(m_cellGraphicsComponents[i].sprite);
 			if (m_cellNumbersComponents[i].isActive)
 			{

--- a/src/Levels/LevelEntityManager.cpp
+++ b/src/Levels/LevelEntityManager.cpp
@@ -102,12 +102,16 @@ namespace Levels
 	{
 		if (m_currentMoveActions.size() == 0)
 		{
-			m_currentShiftAxis = (m_currentShiftAxis == LevelEntityManager::ROW) 
+			m_currentShiftAxis = (m_currentShiftAxis == LevelEntityManager::ROW)
 				? LevelEntityManager::COLUMN : LevelEntityManager::ROW;
-			LevelEntitySystem::createMoveAction(m_currentShiftAxis, m_cellEntityGrid,
-				m_cellMoveComponents, m_currentMoveActions);
-			LevelEntitySystem::updateCellIndicies(m_cellEntityGrid, m_cellTransformComponents,
-				m_cellMoveComponents, 0, m_cellEntityGrid.size() - 1);
+			for(int i = 0; i < 3; i++)
+			{
+				LevelEntitySystem::createMoveAction(m_currentShiftAxis, m_cellEntityGrid,
+					m_cellMoveComponents, m_currentMoveActions);
+				LevelEntitySystem::updateCellIndicies(m_cellEntityGrid, m_cellTransformComponents,
+					m_cellMoveComponents, 0, m_cellEntityGrid.size() - 1);
+			}
+		
 		}
  
 		for (LevelMoveAction& action : m_currentMoveActions)

--- a/src/Levels/LevelEntityManager.cpp
+++ b/src/Levels/LevelEntityManager.cpp
@@ -73,14 +73,7 @@ namespace Levels
 			
 			if (sprite.getLocalBounds().width != cellWidth)
 			{
-				sprite.setScale(
-					cellWidth / sprite.getLocalBounds().width,
-					cellWidth / sprite.getLocalBounds().height
-				);
-				sprite.setOrigin(
-					sprite.getLocalBounds().width * 0.5f,
-					sprite.getLocalBounds().height * 0.5f
-				);
+				LevelEntitySystem::scaleCellSprite(sprite, cellWidth);
 			}
 		}
 		updateAllCellPositions();
@@ -122,7 +115,12 @@ namespace Levels
 			switch (action.getCurrentActionState())
 			{
 			case LevelMoveAction::STARTING:
-				action.beginDrop(m_cellGravityComponents, m_cellCollisionComponents);
+				if (action.hasCountdownCompleted(
+					LevelEntitySystem::getDeltaTime(), m_cellPanelsComponents)
+					)
+				{
+					action.beginDrop(m_cellGravityComponents, m_cellCollisionComponents);
+				}
 				break;
 			case LevelMoveAction::DROPPING:
 				if (action.hasDropCompleted(m_cellGravityComponents))
@@ -185,6 +183,14 @@ namespace Levels
 			if (m_cellNumbersComponents[i].isActive)
 			{
 				window.draw(m_cellNumbersComponents[i].text);
+			}
+			if (m_cellPanelsComponents[i].isVisible)
+			{
+				sf::Sprite& panels = m_cellPanelsComponents[i].sprite;
+				CellTransformComponent& transform = m_cellTransformComponents[i];
+				panels.setPosition(transform.position.x, transform.position.y);
+				LevelEntitySystem::scaleCellSprite(panels, transform.cellWidth);
+				window.draw(panels);
 			}
 		}
 	};
@@ -250,6 +256,11 @@ namespace Levels
 		m_cellMoveComponents.resize(m_totalCells);
 		m_cellGravityComponents.resize(m_totalCells);
 		m_cellNumbersComponents.resize(m_totalCells);
+		m_cellPanelsComponents.resize(m_totalCells);
+		for (CellGraphicsComponent panels : m_cellPanelsComponents)
+		{
+			panels.isVisible = false;
+		}
 
 		int counter = 0;
 		for (int i = 0; i < m_xGridSize; i++)

--- a/src/Levels/LevelEntityManager.h
+++ b/src/Levels/LevelEntityManager.h
@@ -113,6 +113,7 @@ namespace Levels
 		std::vector<CellMoveComponent> m_cellMoveComponents;
 		std::vector<CellGravityComponent> m_cellGravityComponents;
 		std::vector<CellNumbersComponent> m_cellNumbersComponents;
+		std::vector<CellGraphicsComponent> m_cellPanelsComponents;
 
 		sf::Sprite m_backgroundSprite;
 		int m_xGridSize;

--- a/src/Levels/LevelEntitySystem.cpp
+++ b/src/Levels/LevelEntitySystem.cpp
@@ -84,23 +84,30 @@ namespace Levels
 		int lastColumnIndex = cellGrid.size() - 2;
 		int firstRowIndex = 1;
 		int lastRowIndex = cellGrid[0].size() - 2;
-		int columnIndex = firstColumnIndex + rand() % (lastColumnIndex);
-		int rowIndex = firstRowIndex + rand() % (lastRowIndex);
-		
-		int primaryIndex = (axis == COLUMN) ? columnIndex : rowIndex;
+
+		int columnIndex = 0;
+		int rowIndex = 0;
+		int primaryIndex = 0;
 
 		// Check that the row/column index is not held by any existing action
-		if (moveActions.size() > 0)
+		bool idExists = true;
+		while(idExists == true)
 		{
-			for (const LevelMoveAction& action : moveActions)
+			idExists = false;
+			if (moveActions.size() > 0)
 			{
-				if (primaryIndex == action.getRowOrColumn())
+				columnIndex = firstColumnIndex + rand() % (lastColumnIndex);
+				rowIndex = firstRowIndex + rand() % (lastRowIndex);
+				primaryIndex = (axis == COLUMN) ? columnIndex : rowIndex;
+				for (const LevelMoveAction& action : moveActions)
 				{
-					return;
+					if (primaryIndex == action.getRowOrColumn())
+					{
+						idExists = true;
+					}
 				}
 			}
 		}
-
 		// Randomly selcted move direction along corresponding axis
 		CellMoveComponent::State direction = (axis == COLUMN) 
 			? (rand() % (2) == 0)

--- a/src/Levels/LevelEntitySystem.cpp
+++ b/src/Levels/LevelEntitySystem.cpp
@@ -18,6 +18,14 @@ namespace Levels
 		const Physics::CircleParams& actorCircle
 	)
 	{
+		if (cellCollision.isBlocked == true)
+		{
+			if (Physics::checkIntersection(cellCollision.blocker.getRectangle(), actorCircle))
+			{
+				detectedCollisions.blockers.push_back(cellCollision.blocker.getRectangle());
+			}
+		}
+
 		if (cellCollision.areCollisionsActive == false)
 		{
 			return;
@@ -28,6 +36,15 @@ namespace Levels
 			if (Physics::checkIntersection(wallCollision.getRectangle(), actorCircle))
 			{
 				detectedCollisions.staticWalls.push_back(wallCollision.getRectangle());
+			}
+		}
+
+		
+		if (cellCollision.isBlocked == true)
+		{
+			if(Physics::checkIntersection(cellCollision.blocker.getRectangle(), actorCircle))
+			{
+				detectedCollisions.staticWalls.push_back(cellCollision.blocker.getRectangle());
 			}
 		}
 	}
@@ -93,12 +110,12 @@ namespace Levels
 		bool idExists = true;
 		while(idExists == true)
 		{
+			columnIndex = firstColumnIndex + rand() % (lastColumnIndex);
+			rowIndex = firstRowIndex + rand() % (lastRowIndex);
+			primaryIndex = (axis == COLUMN) ? columnIndex : rowIndex;
 			idExists = false;
 			if (moveActions.size() > 0)
 			{
-				columnIndex = firstColumnIndex + rand() % (lastColumnIndex);
-				rowIndex = firstRowIndex + rand() % (lastRowIndex);
-				primaryIndex = (axis == COLUMN) ? columnIndex : rowIndex;
 				for (const LevelMoveAction& action : moveActions)
 				{
 					if (primaryIndex == action.getRowOrColumn())

--- a/src/Levels/LevelEntitySystem.cpp
+++ b/src/Levels/LevelEntitySystem.cpp
@@ -7,6 +7,11 @@ namespace Levels
 		m_deltaTime = deltaTime;
 	}
 
+	float LevelEntitySystem::getDeltaTime()
+	{
+		return m_deltaTime;
+	}
+
 	void LevelEntitySystem::getWallCollisions(
 		DetectedLevelCollisions& detectedCollisions, 
 		const CellCollisionComponent& cellCollision,
@@ -278,6 +283,18 @@ namespace Levels
 		default:
 			break;
 		}
+	}
+
+	void LevelEntitySystem::scaleCellSprite(sf::Sprite& sprite, float cellWidth)
+	{
+		sprite.setScale(
+			cellWidth / sprite.getLocalBounds().width,
+			cellWidth / sprite.getLocalBounds().height
+		);
+		sprite.setOrigin(
+			sprite.getLocalBounds().width * 0.5f,
+			sprite.getLocalBounds().height * 0.5f
+		);
 	}
 
 	void LevelEntitySystem::updateCellNumbers(

--- a/src/Levels/LevelEntitySystem.h
+++ b/src/Levels/LevelEntitySystem.h
@@ -15,6 +15,8 @@ namespace Levels
 	public:
 		static void setDeltaTime(float deltaTime);
 
+		static float getDeltaTime();
+
 		static void getWallCollisions(
 			DetectedLevelCollisions& detectedCollisions,
 			const CellCollisionComponent& cellCollision,
@@ -49,6 +51,8 @@ namespace Levels
 			std::vector<CellMoveComponent>& moveComponents,
 			int startIndex, int endIndex
 		);
+
+		static void scaleCellSprite(sf::Sprite& sprite, float cellWidth);
 
 		static void updateCellNumbers(
 			CellNumbersComponent& numbers

--- a/src/Levels/LevelFactory.cpp
+++ b/src/Levels/LevelFactory.cpp
@@ -131,6 +131,7 @@ namespace Levels
 		{
 			if (cellTypes[i].type == CellTypes::ROOM)
 			{
+				graphics[i].isBackground = false;
 				graphics[i].sprite.setTexture(
 					Assets::TextureDict::getInstance()->getTexture(
 						m_colourFilenames.at(cellTypes[i].colour)

--- a/src/Levels/LevelFactory.cpp
+++ b/src/Levels/LevelFactory.cpp
@@ -29,7 +29,7 @@ namespace Levels
 	{
 		std::string textureNames[9] = {
 			"YellowRoom", "WhiteRoom", "GreenRoom", "BlueRoom", "RedRoom",
-			"CornerVoid", "BridgeVoid", "EdgeVoid", "BackgroundVoid"
+			"CornerVoid", "BridgeVoid", "EdgeVoid", "BackgroundVoid",
 		};
 
 		for (std::string name : textureNames)

--- a/src/Levels/LevelFactory.cpp
+++ b/src/Levels/LevelFactory.cpp
@@ -169,6 +169,8 @@ namespace Levels
 	{
 		for (CellCollisionComponent& collision : cellCollisions)
 		{
+			collision.blocker.setRelativeDimensions(0.95, 0.95);
+			collision.blocker.setRelativePosition(0., 0.);
 			m_addWallCollisions(collision);
 		}
 
@@ -176,6 +178,7 @@ namespace Levels
 		{
 			m_addFloorCollisions(cellTypes[i], cellCollisions[i]);
 		}
+
 	}
 
 	void LevelFactory::m_addWallCollisions(CellCollisionComponent& collision)

--- a/src/Levels/LevelMoveAction.cpp
+++ b/src/Levels/LevelMoveAction.cpp
@@ -2,6 +2,39 @@
 
 namespace Levels
 {
+
+	bool LevelMoveAction::hasCountdownCompleted(
+		float deltaTime, std::vector<CellGraphicsComponent>& panelsComponents)
+	{
+		this->m_dropTimer += deltaTime;
+		CellGraphicsComponent& panels = panelsComponents[this->m_cellToDrop];
+		int stage = floor(5.f * m_dropTimer / m_dropDelay);
+		panels.isVisible = true;
+		Assets::TextureDict* textures = Assets::TextureDict::getInstance();
+		switch (stage)
+		{
+		case 0:
+			panels.sprite.setTexture(textures->getTexture("PanelsBlank"));
+			break;
+		case 1:
+			panels.sprite.setTexture(textures->getTexture("PanelsDiamondOne"));
+			break;
+		case 2:
+			panels.sprite.setTexture(textures->getTexture("PanelsDiamondTwo"));
+			break;
+		case 3:
+			panels.sprite.setTexture(textures->getTexture("PanelsDiamondThree"));
+			break;
+		case 4:
+			panels.sprite.setTexture(textures->getTexture("PanelsDiamondFour"));
+			break;
+		default:
+			panels.isVisible = false;
+			break;
+		}
+		return !panels.isVisible;
+	}
+
 	bool LevelMoveAction::hasDropCompleted(
 		const std::vector<CellGravityComponent>& gravityComponents) const
 	{
@@ -120,8 +153,16 @@ namespace Levels
 
 	LevelMoveAction::LevelMoveAction(int rowOrColumn)
 	{
-		m_rowOrColumn = rowOrColumn;
+		this->m_rowOrColumn = rowOrColumn;
+		this->m_dropDelay = 4.f;
 	}
+
+	LevelMoveAction::LevelMoveAction(int rowOrColumn, float dropDelay)
+	{
+		this->m_rowOrColumn = rowOrColumn;
+		this->m_dropDelay = dropDelay;
+	}
+
 	
 	LevelMoveAction::~LevelMoveAction()
 	{

--- a/src/Levels/LevelMoveAction.h
+++ b/src/Levels/LevelMoveAction.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "Levels/CellComponents.h"
+#include "Assets/TextureDict.h"
+#include "Math.h"
 
 namespace Levels
 {
@@ -14,6 +16,9 @@ namespace Levels
 			CLIMBING = 3,
 			ENDED = 4
 		};
+
+		bool hasCountdownCompleted(
+			float deltaTime, std::vector<CellGraphicsComponent>& panelsComponents);
 
 		/**
 		 * @brief Check if the first cell has vanished before shifting.
@@ -55,14 +60,16 @@ namespace Levels
 		void addShiftCellId(int id);
 		void setShiftAction(CellMoveComponent::State shiftAction);
 		
-
 		LevelMoveAction(int rowOrColumn);
+		LevelMoveAction(int rowOrColumn, float dropDelay);
 		~LevelMoveAction();
 
 	private:
 		std::vector<int> m_cellsToShift;
 		int m_cellToDrop = 0;
 		int m_rowOrColumn = 0;
+		float m_dropTimer = 0.f;
+		float m_dropDelay = 4.f;
 		State m_actionState = STARTING;
 		CellMoveComponent::State m_shiftAction = CellMoveComponent::STATIC;
 	};

--- a/src/Scenes/GameScene.cpp
+++ b/src/Scenes/GameScene.cpp
@@ -187,6 +187,7 @@ namespace Scenes
 				if (m_actors->gravityComponents[actorId].ActorState == 
 						Actors::ActorGravityComponent::STEADY && !levelCollisions.isFloorDetected)
 				{	
+					m_actors->gravityComponents[actorId].voidCentre = levelCollisions.voidCentre;
 					m_actors->gravityComponents[actorId].ActorState = 
 						Actors::ActorGravityComponent::FALLING;				
 				}
@@ -195,7 +196,8 @@ namespace Scenes
 					Actors::ActorGravityComponent::STEADY)
 				{
 					Actors::ActorEntitySystem::adjustGravityMotion(
-						m_actors->gravityComponents[actorId]);
+						m_actors->gravityComponents[actorId],
+						m_actors->transformComponents[actorId]);
 					continue;
 				}
 				
@@ -212,6 +214,16 @@ namespace Scenes
 					m_actors->transformComponents[actorId],
 					m_actors->collisionComponents[actorId],
 					levelCollisions.staticWalls
+				);
+			}
+
+			if (levelCollisions.blockers.size() > 0 &&
+				m_actors->typeComponents[actorId].type == Actors::ActorTypes::PLAYER)
+			{
+				Actors::ActorEntitySystem::applyWallCollisions(
+					m_actors->transformComponents[actorId],
+					m_actors->collisionComponents[actorId],
+					levelCollisions.blockers
 				);
 			}
 

--- a/src/Scenes/GameScene.cpp
+++ b/src/Scenes/GameScene.cpp
@@ -49,8 +49,9 @@ namespace Scenes
 		);
 		m_window->setView(*m_view);
 		m_level->renderBackground(*m_window);
+		m_actors->renderBackgroundActors(*m_window);
 		m_level->renderLevel(*m_window);
-		m_actors->renderActors(*m_window);
+		m_actors->renderForegroundActors(*m_window);
 	}
 
 	void GameScene::updateScene()


### PR DESCRIPTION
### Purpose

To finalise the falling mechanics of the player and the rooms.

### Action

- Modified the player falling action ot slowly pull the player towards the center of the corresponding void.
- Added an invivislbe 'blocker wall' to prevent the player from falling into a rising room.
- Configured the LevelEntityManager to deactivate numbers on rising or falling rooms.

### Notes

- The blocker serves no in-game purpose. It's simply there to eliminate the need for complex collision mechanics between falling players and rising rooms.

