### PR TITLE
Title scene

### DIFF
--- a/resources/graphics/TitleBackground.png
+++ b/resources/graphics/TitleBackground.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54064c7b322adad0fda57283ce9f665e55fa71d7c406b04d23b6a38168392d8b
+size 2490561

--- a/src/Engine/Action.cpp
+++ b/src/Engine/Action.cpp
@@ -2,7 +2,7 @@
 
 namespace Engine
 {
-	const Scenes::GameSceneActions& Action::getName() const
+	const Scenes::SceneActions& Action::getName() const
 	{
 		return m_name;
 	}
@@ -27,7 +27,7 @@ namespace Engine
 		return m_properties.count(property) > 0;
 	}
 
-	Action::Action(Scenes::GameSceneActions name, ActionType type)
+	Action::Action(Scenes::SceneActions name, ActionType type)
 	{
 		m_name = name;
 		m_type = type;

--- a/src/Engine/Action.cpp
+++ b/src/Engine/Action.cpp
@@ -2,56 +2,43 @@
 
 namespace Engine
 {
-	template <typename T>
-	const T& Action<T>::getName() const
+	const Scenes::GameSceneActions& Action::getName() const
 	{
 		return m_name;
 	}
 
-	template <typename T>
-	const ActionType& Action<T>::getType() const
+	const ActionType& Action::getType() const
 	{
 		return m_type;
 	}
 
-	template<typename T>
-	void Action<T>::setProperty(std::string property, float value)
+	void Action::setProperty(std::string property, float value)
 	{
 		m_properties.insert({property, value});
 	}
 
-	template<typename T>
-	float Action<T>::getProperty(std::string property)
+	float Action::getProperty(std::string property)
 	{
 		return m_properties.find(property)->second;
 	}
 
-	template<typename T>
-	bool Action<T>::checkProperty(std::string property)
+	bool Action::checkProperty(std::string property)
 	{
 		return m_properties.count(property) > 0;
 	}
 
-	template<typename T>
-	void setProperty(std::string property, float value)
-	{
-		m_properties.insert({ property, value });
-	}
-
-	template <typename T>
-	Action<T>::Action<T>(T name, ActionType type)
+	Action::Action(Scenes::GameSceneActions name, ActionType type)
 	{
 		m_name = name;
 		m_type = type;
 	}
 
-	template <typename T>
-	Action<T>::~Action<T>()
+	Action::~Action()
 	{
 
 	}	
 }
 
-template class Engine::Action<Scenes::GameSceneActions>;
+//template class Engine::Action<Scenes::GameSceneActions>;
 
-template class Engine::Action<Scenes::TitleSceneActions>;
+//template class Engine::Action<Scenes::TitleSceneActions>;

--- a/src/Engine/Action.h
+++ b/src/Engine/Action.h
@@ -16,18 +16,18 @@ namespace Engine
 	class Action
 	{
 	public:
-		const Scenes::GameSceneActions& getName() const;
+		const Scenes::SceneActions& getName() const;
 		const ActionType& getType() const;
 
 		void setProperty(std::string property, float value);
 		float getProperty(std::string property);
 		bool checkProperty(std::string property);
 
-		Action(Scenes::GameSceneActions name, ActionType type);
+		Action(Scenes::SceneActions name, ActionType type);
 		~Action();
 	
 	private:
-		Scenes::GameSceneActions m_name;
+		Scenes::SceneActions m_name;
 		ActionType m_type;
 		std::map<std::string, float> m_properties;
 	};

--- a/src/Engine/Action.h
+++ b/src/Engine/Action.h
@@ -13,22 +13,21 @@ namespace Engine
 		RELEASE
 	};
 
-	template <typename T>
 	class Action
 	{
 	public:
-		const T& getName() const;
+		const Scenes::GameSceneActions& getName() const;
 		const ActionType& getType() const;
 
 		void setProperty(std::string property, float value);
 		float getProperty(std::string property);
 		bool checkProperty(std::string property);
 
-		Action(T name, ActionType type);
+		Action(Scenes::GameSceneActions name, ActionType type);
 		~Action();
 	
 	private:
-		T m_name;
+		Scenes::GameSceneActions m_name;
 		ActionType m_type;
 		std::map<std::string, float> m_properties;
 	};

--- a/src/Engine/GameEngine.cpp
+++ b/src/Engine/GameEngine.cpp
@@ -50,8 +50,8 @@ namespace Engine
 		//if (typeid(*m_currentScene) == typeid(Scenes::GameScene))
 		if (m_currentScene != nullptr)
 		{
-			Scenes::GameSceneActions sceneAction = m_currentScene->checkInput(key);
-			if (sceneAction != Scenes::GameSceneActions::NONE)
+			Scenes::SceneActions sceneAction = m_currentScene->checkInput(key);
+			if (sceneAction != Scenes::SceneActions::NONE)
 			{
 				ActionType type = (eventType == sf::Event::KeyPressed) ? PRESS : RELEASE;
 				Action newAction = Action(sceneAction, type);
@@ -65,7 +65,7 @@ namespace Engine
 		if (typeid(*m_currentScene) == typeid(Scenes::GameScene))
 		{
 			Action newAction = Action(
-				Scenes::GameSceneActions::SET_CURSOR, Engine::ActionType::NONE
+				Scenes::SceneActions::SET_CURSOR, Engine::ActionType::NONE
 			);
 			newAction.setProperty("x", xCursor);
 			newAction.setProperty("y", yCursor);

--- a/src/Engine/GameEngine.cpp
+++ b/src/Engine/GameEngine.cpp
@@ -13,6 +13,22 @@ namespace Engine
 		
 		while (window->isOpen())
 		{
+			Scenes::SceneNames nextScene = m_currentScene->checkNextScene();
+			if (nextScene != Scenes::SceneNames::NONE)
+			{
+				switch (nextScene)
+				{
+				case Scenes::SceneNames::LEVEL:
+					m_currentScene = std::make_unique<Scenes::GameScene>();
+					break;
+				default:
+					break;
+				}
+				m_currentScene->setRenderWindow(window);
+				m_currentScene->setView(playerView);
+			}
+			
+
 			m_frameTimer.restart();
 			m_currentScene->setDeltaTime(m_lastDeltaTime);
 
@@ -31,13 +47,14 @@ namespace Engine
 
 	void GameEngine::checkInput(sf::Keyboard::Key key, sf::Event::EventType eventType)
 	{
-		if (typeid(*m_currentScene) == typeid(Scenes::GameScene))
+		//if (typeid(*m_currentScene) == typeid(Scenes::GameScene))
+		if (m_currentScene != nullptr)
 		{
 			Scenes::GameSceneActions sceneAction = m_currentScene->checkInput(key);
 			if (sceneAction != Scenes::GameSceneActions::NONE)
 			{
 				ActionType type = (eventType == sf::Event::KeyPressed) ? PRESS : RELEASE;
-				Action newAction = Action<Scenes::GameSceneActions>(sceneAction, type);
+				Action newAction = Action(sceneAction, type);
 				m_currentScene->processAction(newAction);
 			}
 		}
@@ -47,7 +64,7 @@ namespace Engine
 	{
 		if (typeid(*m_currentScene) == typeid(Scenes::GameScene))
 		{
-			Action newAction = Action<Scenes::GameSceneActions>(
+			Action newAction = Action(
 				Scenes::GameSceneActions::SET_CURSOR, Engine::ActionType::NONE
 			);
 			newAction.setProperty("x", xCursor);
@@ -71,7 +88,7 @@ namespace Engine
 		);
 		playerView->setViewport(sf::FloatRect(-0.f, -0.f, 1.f, 1.f));
 	
-		m_currentScene = std::make_unique<Scenes::GameScene>();
+		m_currentScene = std::make_unique<Scenes::TitleScene>();
 		m_currentScene->setRenderWindow(window);
 		m_currentScene->setView(playerView);
 	}

--- a/src/Engine/GameEngine.h
+++ b/src/Engine/GameEngine.h
@@ -5,6 +5,7 @@
 #include "Engine/Inputs.h"
 #include "Assets/TextureDict.h"
 #include "Scenes/GameScene.h"
+#include "Scenes/TitleScene.h"
 #include "Engine/GameEngine.h"
 #include "Engine/Action.h"
 
@@ -28,7 +29,7 @@ namespace Engine
 		GameEngine();
 
 	private:
-		std::unique_ptr<Scenes::Scene<Scenes::GameSceneActions>> m_currentScene;
+		std::unique_ptr<Scenes::Scene> m_currentScene;
 		sf::Clock m_frameTimer;
 		float m_lastDeltaTime;
 	};

--- a/src/Scenes/GameScene.cpp
+++ b/src/Scenes/GameScene.cpp
@@ -14,7 +14,7 @@ namespace Scenes
 		 }
 	 }
 
-	 void GameScene::processAction(Engine::Action<GameSceneActions> action)
+	 void GameScene::processAction(Engine::Action action)
 	 {
 		 switch (action.getName())
 		 {
@@ -106,7 +106,7 @@ namespace Scenes
 		);
 	}
 
-	void GameScene::m_setPlayerMovement(Engine::Action<GameSceneActions> action)
+	void GameScene::m_setPlayerMovement(Engine::Action action)
 	{
 		m_playerMoves[action.getName()] = (action.getType() == Engine::PRESS) ? true : false;
 
@@ -232,6 +232,8 @@ namespace Scenes
 
 			actorId++;	
 		}
+
+
 	}
 
 }

--- a/src/Scenes/GameScene.cpp
+++ b/src/Scenes/GameScene.cpp
@@ -2,7 +2,7 @@
 
 namespace Scenes
 {
-	 GameSceneActions GameScene::checkInput(sf::Keyboard::Key key)
+	 SceneActions GameScene::checkInput(sf::Keyboard::Key key)
 	 {
 		 if (m_availableKeyActions.count(key) > 0)
 		 {
@@ -10,7 +10,7 @@ namespace Scenes
 		 }
 		 else
 		 {
-			 return GameSceneActions::NONE;
+			 return SceneActions::NONE;
 		 }
 	 }
 
@@ -18,13 +18,13 @@ namespace Scenes
 	 {
 		 switch (action.getName())
 		 {
-			case GameSceneActions::MOVE_UP:
-			case GameSceneActions::MOVE_DOWN:
-			case GameSceneActions::MOVE_LEFT:
-			case GameSceneActions::MOVE_RIGHT:
+			case SceneActions::MOVE_UP:
+			case SceneActions::MOVE_DOWN:
+			case SceneActions::MOVE_LEFT:
+			case SceneActions::MOVE_RIGHT:
 				m_setPlayerMovement(action);
 				break;
-			case GameSceneActions::SET_CURSOR:
+			case SceneActions::SET_CURSOR:
 				if (action.checkProperty("x") && action.checkProperty("y"))
 				{
 					m_cursorPosition = Physics::Vec2f(
@@ -33,7 +33,7 @@ namespace Scenes
 						);
 				}
 				break;			
-			case GameSceneActions::EXIT:
+			case SceneActions::EXIT:
 				m_window->close();
 				break;
 			default:
@@ -112,12 +112,12 @@ namespace Scenes
 
 		if (action.getType() == Engine::PRESS)
 		{	
-			std::map<GameSceneActions, GameSceneActions> opposites
+			std::map<SceneActions, SceneActions> opposites
 			{
-				{GameSceneActions::MOVE_UP, GameSceneActions::MOVE_DOWN},
-				{GameSceneActions::MOVE_DOWN, GameSceneActions::MOVE_UP},
-				{GameSceneActions::MOVE_LEFT, GameSceneActions::MOVE_RIGHT},
-				{GameSceneActions::MOVE_RIGHT, GameSceneActions::MOVE_LEFT}
+				{SceneActions::MOVE_UP, SceneActions::MOVE_DOWN},
+				{SceneActions::MOVE_DOWN, SceneActions::MOVE_UP},
+				{SceneActions::MOVE_LEFT, SceneActions::MOVE_RIGHT},
+				{SceneActions::MOVE_RIGHT, SceneActions::MOVE_LEFT}
 			};
 
 			m_playerMoves[opposites[action.getName()]] = false;
@@ -126,15 +126,15 @@ namespace Scenes
 
 	void GameScene::m_setPlayerAngle()
 	{
-		std::map<GameSceneActions, float> movementAngles
+		std::map<SceneActions, float> movementAngles
 		{
-			{GameSceneActions::MOVE_RIGHT, 0.f}, {GameSceneActions::MOVE_DOWN, 90.f},
-			{GameSceneActions::MOVE_LEFT, 180.f}, {GameSceneActions::MOVE_UP, 270.f}
+			{SceneActions::MOVE_RIGHT, 0.f}, {SceneActions::MOVE_DOWN, 90.f},
+			{SceneActions::MOVE_LEFT, 180.f}, {SceneActions::MOVE_UP, 270.f}
 		};
 
 		int counter = 0;
 		float angle = 0.f;
-		for (const std::pair<GameSceneActions, float>& action : movementAngles)
+		for (const std::pair<SceneActions, float>& action : movementAngles)
 		{
 			if (m_playerMoves[action.first])
 			{
@@ -143,8 +143,8 @@ namespace Scenes
 			}
 		}
 
-		if (m_playerMoves[GameSceneActions::MOVE_UP] &&
-			m_playerMoves[GameSceneActions::MOVE_RIGHT])
+		if (m_playerMoves[SceneActions::MOVE_UP] &&
+			m_playerMoves[SceneActions::MOVE_RIGHT])
 		{
 			angle += 360.f;
 		}

--- a/src/Scenes/GameScene.h
+++ b/src/Scenes/GameScene.h
@@ -18,7 +18,7 @@ namespace Scenes
 	class GameScene : public Scene
 	{
 	public:
-		GameSceneActions checkInput(sf::Keyboard::Key) override;
+		SceneActions checkInput(sf::Keyboard::Key) override;
 		void processAction(Engine::Action) override;
 		void updateScene() override;
 		void renderScene() override;
@@ -29,21 +29,21 @@ namespace Scenes
 	private:
 		std::unique_ptr<Levels::LevelEntityManager> m_level;
 		std::unique_ptr<Actors::ActorEntityManager> m_actors;
-		std::map<sf::Keyboard::Key, GameSceneActions> m_availableKeyActions 
+		std::map<sf::Keyboard::Key, SceneActions> m_availableKeyActions 
 		{
-			{ sf::Keyboard::W, GameSceneActions::MOVE_UP },
-			{ sf::Keyboard::S, GameSceneActions::MOVE_DOWN },
-			{ sf::Keyboard::A, GameSceneActions::MOVE_LEFT },
-			{ sf::Keyboard::D, GameSceneActions::MOVE_RIGHT },
-			{ sf::Keyboard::Escape, GameSceneActions::EXIT }
+			{ sf::Keyboard::W, SceneActions::MOVE_UP },
+			{ sf::Keyboard::S, SceneActions::MOVE_DOWN },
+			{ sf::Keyboard::A, SceneActions::MOVE_LEFT },
+			{ sf::Keyboard::D, SceneActions::MOVE_RIGHT },
+			{ sf::Keyboard::Escape, SceneActions::EXIT }
 		};
 	
-		std::map<GameSceneActions, bool> m_playerMoves
+		std::map<SceneActions, bool> m_playerMoves
 		{
-			{GameSceneActions::MOVE_UP, false},
-			{GameSceneActions::MOVE_DOWN, false},
-			{GameSceneActions::MOVE_LEFT, false},
-			{GameSceneActions::MOVE_RIGHT, false}
+			{SceneActions::MOVE_UP, false},
+			{SceneActions::MOVE_DOWN, false},
+			{SceneActions::MOVE_LEFT, false},
+			{SceneActions::MOVE_RIGHT, false}
 		};
 
 		Physics::Vec2f m_cursorPosition;

--- a/src/Scenes/GameScene.h
+++ b/src/Scenes/GameScene.h
@@ -15,11 +15,11 @@
 
 namespace Scenes
 {
-	class GameScene : public Scene<GameSceneActions>
+	class GameScene : public Scene
 	{
 	public:
 		GameSceneActions checkInput(sf::Keyboard::Key) override;
-		void processAction(Engine::Action<GameSceneActions>) override;
+		void processAction(Engine::Action) override;
 		void updateScene() override;
 		void renderScene() override;
 		void setDeltaTime(float deltaTime) override;
@@ -48,7 +48,7 @@ namespace Scenes
 
 		Physics::Vec2f m_cursorPosition;
 
-		void m_setPlayerMovement(Engine::Action<GameSceneActions> action);
+		void m_setPlayerMovement(Engine::Action action);
 		void m_setPlayerAngle();
 		void m_processCollisions();
 	};

--- a/src/Scenes/GameSceneActions.h
+++ b/src/Scenes/GameSceneActions.h
@@ -10,6 +10,7 @@ namespace Scenes
 		MOVE_DOWN,
 		MOVE_RIGHT,
 		MOVE_LEFT,
-		SET_CURSOR
+		SET_CURSOR,
+		START
 	};
 }

--- a/src/Scenes/GameSceneActions.h
+++ b/src/Scenes/GameSceneActions.h
@@ -2,7 +2,7 @@
 
 namespace Scenes
 {
-	enum class GameSceneActions
+	enum class SceneActions
 	{
 		NONE,
 		EXIT,

--- a/src/Scenes/Scene.cpp
+++ b/src/Scenes/Scene.cpp
@@ -2,25 +2,25 @@
 
 namespace Scenes
 {
-	template <typename T>
-	void Scene<T>::setRenderWindow(std::shared_ptr<sf::RenderWindow> window)
+	SceneNames Scene::checkNextScene()
+	{
+		SceneNames nextScene = m_nextScene;
+		m_nextScene = SceneNames::NONE;
+		return nextScene;
+	}
+
+	void Scene::setRenderWindow(std::shared_ptr<sf::RenderWindow> window)
 	{
 		m_window = window;
 	}
 
-	template <typename T>
-	void Scene<T>::setView(std::shared_ptr<sf::View> view)
+	void Scene::setView(std::shared_ptr<sf::View> view)
 	{
 		m_view = view;
 	}
 
-	template <typename T>
-	Scene<T>::Scene<T>()
+	Scene::Scene()
 	{
 
 	}
 }
-
-template class Scenes::Scene<Scenes::GameSceneActions>::Scene;
-
-template class Scenes::Scene<Scenes::TitleSceneActions>::Scene;

--- a/src/Scenes/Scene.h
+++ b/src/Scenes/Scene.h
@@ -11,7 +11,7 @@ namespace Scenes
     class Scene
     {
     public:
-        GameSceneActions virtual checkInput(sf::Keyboard::Key) = 0;
+        SceneActions virtual checkInput(sf::Keyboard::Key) = 0;
         void virtual processAction(Engine::Action action) = 0;
         void virtual updateScene() = 0;
         void virtual renderScene() = 0;

--- a/src/Scenes/Scene.h
+++ b/src/Scenes/Scene.h
@@ -8,15 +8,16 @@
 
 namespace Scenes
 {
-    template <typename T>
     class Scene
     {
     public:
-        T virtual checkInput(sf::Keyboard::Key) = 0;
-        void virtual processAction(Engine::Action<T> action) = 0;
+        GameSceneActions virtual checkInput(sf::Keyboard::Key) = 0;
+        void virtual processAction(Engine::Action action) = 0;
         void virtual updateScene() = 0;
         void virtual renderScene() = 0;
         void virtual setDeltaTime(float deltaTime) = 0;
+
+        SceneNames checkNextScene();
 
         void setRenderWindow(std::shared_ptr<sf::RenderWindow> window);
         void setView(std::shared_ptr<sf::View> view);
@@ -25,6 +26,7 @@ namespace Scenes
 
     protected:
         std::shared_ptr<sf::RenderWindow> m_window;
-        std::shared_ptr<sf::View> m_view; 
+        std::shared_ptr<sf::View> m_view;
+        SceneNames m_nextScene = SceneNames::NONE;
     };
 }

--- a/src/Scenes/TitleScene.cpp
+++ b/src/Scenes/TitleScene.cpp
@@ -2,7 +2,7 @@
 
 namespace Scenes
 {
-	GameSceneActions TitleScene::checkInput(sf::Keyboard::Key key)
+	SceneActions TitleScene::checkInput(sf::Keyboard::Key key)
 	{
 		if (m_availableKeyActions.count(key) > 0)
 		{
@@ -10,7 +10,7 @@ namespace Scenes
 		}
 		else
 		{
-			return GameSceneActions::NONE;
+			return SceneActions::NONE;
 		}
 	}
 
@@ -18,10 +18,10 @@ namespace Scenes
 	{
 		switch (action.getName())
 		{
-		case GameSceneActions::START:
+		case SceneActions::START:
 			m_nextScene = SceneNames::LEVEL;
 			break;
-		case GameSceneActions::SET_CURSOR:
+		case SceneActions::SET_CURSOR:
 			if (action.checkProperty("x") && action.checkProperty("y"))
 			{
 				m_cursorPosition = vecp::Vec2f(
@@ -30,7 +30,7 @@ namespace Scenes
 				);
 			}
 			break;
-		case GameSceneActions::EXIT:
+		case SceneActions::EXIT:
 			m_window->close();
 			break;
 		default:
@@ -47,24 +47,21 @@ namespace Scenes
 
 	void TitleScene::updateScene()
 	{
+		m_resizeBackground();
 		m_textTime += m_deltaTime;
 		if (m_textTime > m_textPeriod)
 		{
 			m_textTime = 0.f;
 		}
-		int opacity = static_cast<int>(255.f * m_textTime / m_textPeriod);
+		int opacity = (m_textTime < 0.5f * m_textPeriod) ? 255.f : 0.f;
 		m_mainText.setColor(sf::Color(255, 255, 255, opacity));
-
+		m_mainText.setOutlineColor(sf::Color(0, 0, 0, opacity));
+		m_mainText.setOutlineThickness(3);
 	}
 
 	void TitleScene::setDeltaTime(float deltaTime)
 	{
 		m_deltaTime = deltaTime;
-	}
-
-	void TitleScene::setWindowSize(float xSize, float ySize)
-	{
-		m_windowSize = vecp::Vec2f(xSize, ySize);
 	}
 
 	TitleScene::TitleScene()
@@ -74,15 +71,25 @@ namespace Scenes
 			Assets::FontDict::getInstance()->getFont("Tuffy")
 		);
 		m_mainText.setString(sf::String("Press Space To Start"));
-		m_mainText.setPosition(100,100);
+		m_mainText.setPosition(500,500);
 
 		//m_mainText.setColor(sf::Color(255, 255, 255, 128));
 		
-
 		Assets::TextureDict::getInstance()->loadTexture("TitleBackground");
 		m_currentBackground.setTexture(
 			Assets::TextureDict::getInstance()->getTexture("TitleBackground")
 		);
+
+	}
+
+	void TitleScene::m_resizeBackground()
+	{
+		float scale = m_window->getSize().y / m_currentBackground.getGlobalBounds().height;
+		m_currentBackground.scale(scale, scale);		
+	
+		float width = m_currentBackground.getGlobalBounds().width;
+		float offset = (0.5f * width) - (0.5f * m_window->getSize().x);
+		m_currentBackground.setPosition(-offset, 0);
 	}
 
 }

--- a/src/Scenes/TitleScene.cpp
+++ b/src/Scenes/TitleScene.cpp
@@ -43,11 +43,15 @@ namespace Scenes
 		m_window->setView(*m_view);
 		m_window->draw(m_currentBackground);
 		m_window->draw(m_mainText);
+		m_window->draw(m_titleText);
 	}
 
 	void TitleScene::updateScene()
 	{
 		m_resizeBackground();
+		m_titleText.setPosition(0.5f * m_window->getSize().x, 0.4f * m_window->getSize().y);
+		m_mainText.setPosition(0.5f * m_window->getSize().x, 0.8f * m_window->getSize().y);
+
 		m_textTime += m_deltaTime;
 		if (m_textTime > m_textPeriod)
 		{
@@ -72,6 +76,26 @@ namespace Scenes
 		);
 		m_mainText.setString(sf::String("Press Space To Start"));
 		m_mainText.setPosition(500,500);
+		m_mainText.setOrigin(
+			0.5f * m_mainText.getGlobalBounds().width,
+			0.5f * m_mainText.getGlobalBounds().height
+		);
+
+		m_titleText.setFont(
+			Assets::FontDict::getInstance()->getFont("Tuffy")
+		);
+
+		m_titleText.setString(sf::String("CUBE"));
+		m_titleText.setColor(sf::Color(0, 51, 102));
+		m_titleText.setOutlineColor(sf::Color(255, 255, 255));
+		m_titleText.setOutlineThickness(3);
+		m_titleText.setCharacterSize(100);
+		m_titleText.setOrigin(
+			0.5f * m_titleText.getGlobalBounds().width,
+			0.5f * m_titleText.getGlobalBounds().height
+		);
+
+
 
 		//m_mainText.setColor(sf::Color(255, 255, 255, 128));
 		
@@ -85,11 +109,11 @@ namespace Scenes
 	void TitleScene::m_resizeBackground()
 	{
 		float scale = m_window->getSize().y / m_currentBackground.getGlobalBounds().height;
-		m_currentBackground.scale(scale, scale);		
+		m_currentBackground.scale(scale, scale);
 	
 		float width = m_currentBackground.getGlobalBounds().width;
-		float offset = (0.5f * width) - (0.5f * m_window->getSize().x);
-		m_currentBackground.setPosition(-offset, 0);
+		//float offset = (0.5f * width) - (0.5f * m_window->getSize().x);
+		//m_currentBackground.setPosition(-offset, 0);	
 	}
 
 }

--- a/src/Scenes/TitleScene.cpp
+++ b/src/Scenes/TitleScene.cpp
@@ -2,7 +2,7 @@
 
 namespace Scenes
 {
-	TitleSceneActions TitleScene::checkInput(sf::Keyboard::Key key)
+	GameSceneActions TitleScene::checkInput(sf::Keyboard::Key key)
 	{
 		if (m_availableKeyActions.count(key) > 0)
 		{
@@ -10,27 +10,27 @@ namespace Scenes
 		}
 		else
 		{
-			return TitleSceneActions::NONE;
+			return GameSceneActions::NONE;
 		}
 	}
 
-	void TitleScene::processAction(Engine::Action<TitleSceneActions> action)
+	void TitleScene::processAction(Engine::Action action)
 	{
 		switch (action.getName())
 		{
-		case TitleSceneActions::START:
+		case GameSceneActions::START:
 			m_nextScene = SceneNames::LEVEL;
 			break;
-		case TitleSceneActions::SET_CURSOR:
+		case GameSceneActions::SET_CURSOR:
 			if (action.checkProperty("x") && action.checkProperty("y"))
 			{
-				m_cursorPosition = Physics::Vec2f(
+				m_cursorPosition = vecp::Vec2f(
 					action.getProperty("x"),
 					action.getProperty("y")
 				);
 			}
 			break;
-		case TitleSceneActions::EXIT:
+		case GameSceneActions::EXIT:
 			m_window->close();
 			break;
 		default:
@@ -42,35 +42,47 @@ namespace Scenes
 	{
 		m_window->setView(*m_view);
 		m_window->draw(m_currentBackground);
+		m_window->draw(m_mainText);
 	}
 
 	void TitleScene::updateScene()
 	{
-			
+		m_textTime += m_deltaTime;
+		if (m_textTime > m_textPeriod)
+		{
+			m_textTime = 0.f;
+		}
+		int opacity = static_cast<int>(255.f * m_textTime / m_textPeriod);
+		m_mainText.setColor(sf::Color(255, 255, 255, opacity));
+
 	}
 
 	void TitleScene::setDeltaTime(float deltaTime)
 	{
-		float m_deltaTime = deltaTime;
+		m_deltaTime = deltaTime;
 	}
 
 	void TitleScene::setWindowSize(float xSize, float ySize)
 	{
-		m_windowSize = Physics::Vec2f(xSize, ySize);
+		m_windowSize = vecp::Vec2f(xSize, ySize);
 	}
-
-	SceneNames TitleScene::checkNextScene()
-	{
-		SceneNames nextScene = m_nextScene;
-		m_nextScene = SceneNames::NONE;
-		return nextScene;
-	}
-
-
 
 	TitleScene::TitleScene()
 	{
+		Assets::FontDict::getInstance()->loadFont("Tuffy");
+		m_mainText.setFont(
+			Assets::FontDict::getInstance()->getFont("Tuffy")
+		);
+		m_mainText.setString(sf::String("Press Space To Start"));
+		m_mainText.setPosition(100,100);
+
+		//m_mainText.setColor(sf::Color(255, 255, 255, 128));
 		
+
+		Assets::TextureDict::getInstance()->loadTexture("TitleBackground");
+		m_currentBackground.setTexture(
+			Assets::TextureDict::getInstance()->getTexture("TitleBackground")
+		);
 	}
 
 }

--- a/src/Scenes/TitleScene.h
+++ b/src/Scenes/TitleScene.h
@@ -12,28 +12,28 @@ namespace Scenes
 	class TitleScene : public Scene
 	{
 	public:
-		GameSceneActions checkInput(sf::Keyboard::Key) override;
+		SceneActions checkInput(sf::Keyboard::Key) override;
 		void processAction(Engine::Action) override;
 		void updateScene() override;
 		void renderScene() override;
 		void setDeltaTime(float deltaTime) override;
 
-		void setWindowSize(float xSize, float ySize);
-
 		TitleScene();
 
 	private:
-		vecp::Vec2f m_windowSize;
 		sf::Sprite m_currentBackground;
-		std::map<sf::Keyboard::Key, GameSceneActions> m_availableKeyActions
+		std::map<sf::Keyboard::Key, SceneActions> m_availableKeyActions
 		{
-			{ sf::Keyboard::Space, GameSceneActions::START},
-			{ sf::Keyboard::Escape, GameSceneActions::EXIT}
+			{ sf::Keyboard::Space, SceneActions::START},
+			{ sf::Keyboard::Escape, SceneActions::EXIT}
 		};
 		vecp::Vec2f m_cursorPosition;
 		sf::Text m_mainText;
+		sf::Text m_titleText;
 		float m_deltaTime = 0.001;
-		float m_textPeriod = 3.f;
+		float m_textPeriod = 2.f;
 		float m_textTime = 0.f;
+
+		void m_resizeBackground();
 	};
 }

--- a/src/Scenes/TitleScene.h
+++ b/src/Scenes/TitleScene.h
@@ -1,34 +1,39 @@
 #pragma once
 #include "Scenes/Scene.h"
-#include "Scenes/TitleSceneActions.h"
-#include "Physics/Vec2.h"
+#include "Scenes/GameSceneActions.h"
+#include "Assets/TextureDict.h"
+#include "Assets/FontDict.h"
+
+#include <VecPlus/Vec2.h>
+
 
 namespace Scenes
 {
-	class TitleScene : public Scene<TitleSceneActions>
+	class TitleScene : public Scene
 	{
 	public:
-		TitleSceneActions checkInput(sf::Keyboard::Key) override;
-		void processAction(Engine::Action<TitleSceneActions>) override;
+		GameSceneActions checkInput(sf::Keyboard::Key) override;
+		void processAction(Engine::Action) override;
 		void updateScene() override;
 		void renderScene() override;
 		void setDeltaTime(float deltaTime) override;
 
 		void setWindowSize(float xSize, float ySize);
-		SceneNames checkNextScene();
 
 		TitleScene();
 
 	private:
-		Physics::Vec2f m_windowSize;
+		vecp::Vec2f m_windowSize;
 		sf::Sprite m_currentBackground;
-		std::map<sf::Keyboard::Key, TitleSceneActions> m_availableKeyActions
+		std::map<sf::Keyboard::Key, GameSceneActions> m_availableKeyActions
 		{
-			{ sf::Keyboard::W, TitleSceneActions::START},
-			{ sf::Keyboard::Escape, TitleSceneActions::EXIT }
+			{ sf::Keyboard::Space, GameSceneActions::START},
+			{ sf::Keyboard::Escape, GameSceneActions::EXIT}
 		};
-		Physics::Vec2f m_cursorPosition;
-		SceneNames m_nextScene;
-		float m_deltaTime;
+		vecp::Vec2f m_cursorPosition;
+		sf::Text m_mainText;
+		float m_deltaTime = 0.001;
+		float m_textPeriod = 3.f;
+		float m_textTime = 0.f;
 	};
 }


### PR DESCRIPTION
### Overview

Completed the class for the title scene. This scene appears as the fist scene in the game, and transitions into the primary game scene upon user input.

### Features
- Static background which scales to cover the full height of the window.
- Static text displaying the main game title (Cube).
- Dynamic text indicating the action required to advance to the game scene. 

### Additional Changes 
- Replaced the individual 'GameSceneActions' and 'TitleSceneActions' enums with a single enum class containing potential actions for all scenes.
- Changed the Input class from a template class to a fixed type class.
- Added functionality into the main game loop (Within the GameEngine class) to switch scenes when indicated by the current active scene.
